### PR TITLE
Run all tests the same number of times

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -169,7 +169,7 @@ def main():
     print 'PNG 1920x1080 header read:',
     bench_header('1920.png', 10000)
     print 'WEBP 1920x1080 header read:',
-    bench_header('1920.webp', 100)
+    bench_header('1920.webp', 10000)
     print 'GIF 1920x1080 header read:',
     bench_header('1920.gif', 10000)
 

--- a/main.go
+++ b/main.go
@@ -130,16 +130,16 @@ func main() {
 	defer Ops.Close()
 
 	fmt.Printf("JPEG 1920x1080 header read: ")
-	bench_header("1920.jpeg", 100000)
+	bench_header("1920.jpeg", 10000)
 
 	fmt.Printf("PNG 1920x1080 header read: ")
-	bench_header("1920.png", 100000)
+	bench_header("1920.png", 10000)
 
 	fmt.Printf("WEBP 1920x1080 header read: ")
-	bench_header("1920.webp", 100000)
+	bench_header("1920.webp", 10000)
 
 	fmt.Printf("GIF 1920x1080 header read: ")
-	bench_header("1920.gif", 100000)
+	bench_header("1920.gif", 10000)
 
 	fmt.Printf("JPEG 256x256 => 32x32: ")
 	bench_resize("256.jpeg", ".jpeg", 32, 32, 1000)
@@ -166,11 +166,11 @@ func main() {
 	bench_resize("1920.gif", ".gif", 800, 600, 50)
 
 	fmt.Printf("PNG 256x256 => WEBP 256x256: ")
-	bench_transcode("256.png", ".webp", 1000)
+	bench_transcode("256.png", ".webp", 100)
 
 	fmt.Printf("JPEG 256x256 => PNG 256x256: ")
-	bench_transcode("256.jpeg", ".png", 1000)
+	bench_transcode("256.jpeg", ".png", 100)
 
 	fmt.Printf("GIF 256x256 => PNG 256x256: ")
-	bench_transcode("256.gif", ".png", 1000)
+	bench_transcode("256.gif", ".png", 100)
 }


### PR DESCRIPTION
There was s problem in previous versions of Pillow: webp images are fully loaded on opening. That was fixed in more recent versions. For example, this is the results for Pillow-SIMD 5.2.0.post0:

```
JPEG 1920x1080 header read:	1920x1080,	avg: 0.076556 ms	min: 0.072956 ms	max: 0.571966 ms
PNG 1920x1080 header read:	1920x1080,	avg: 0.052778 ms	min: 0.049829 ms	max: 0.294924 ms
WEBP 1920x1080 header read:	1920x1080,	avg: 0.731373 ms	min: 0.219107 ms	max: 150.552034 ms
GIF 1920x1080 header read:	1920x1080,	avg: 0.039907 ms	min: 0.035763 ms	max: 6.623030 ms
```

All other values are changed to match across libraries.