### PR TITLE
Fair competition

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -32,7 +32,7 @@ def resize_gif(blob, width, height, write_to=''):
 
     i = 0
     p = im.getpalette()
-    last_frame = ImageOps.fit(im.convert('RGBA'), (width, height), Image.LANCZOS)
+    last_frame = ImageOps.fit(im.convert('RGBA'), (width, height), Image.BICUBIC)
     frames = []
 
     try:
@@ -45,7 +45,7 @@ def resize_gif(blob, width, height, write_to=''):
             if mode == 'partial':
                 new_frame.paste(last_frame)
 
-            resized_frame = ImageOps.fit(im, (width, height), Image.LANCZOS)
+            resized_frame = ImageOps.fit(im, (width, height), Image.BICUBIC)
             new_frame.paste(resized_frame, (0,0), resized_frame.convert('RGBA'))
 
             i += 1
@@ -108,7 +108,7 @@ def bench_resize(path, output_type, width, height, num_iter):
         start = time.time()
         im = Image.open(blob)
         im = im.convert('RGB' if output_type == 'JPEG' else 'RGBA')
-        im = ImageOps.fit(im, (width, height), Image.LANCZOS)
+        im = ImageOps.fit(im, (width, height), Image.BICUBIC)
         output = StringIO()
         im.save(output, output_type, **save_opts[output_type])
         if i == 0:

--- a/benchmark.py
+++ b/benchmark.py
@@ -107,7 +107,6 @@ def bench_resize(path, output_type, width, height, num_iter):
     for i in xrange(num_iter):
         start = time.time()
         im = Image.open(blob)
-        im = im.convert('RGB' if output_type == 'JPEG' else 'RGBA')
         im = ImageOps.fit(im, (width, height), Image.BICUBIC)
         output = StringIO()
         im.save(output, output_type, **save_opts[output_type])

--- a/benchmark.py
+++ b/benchmark.py
@@ -2,6 +2,9 @@ import time
 from cStringIO import StringIO
 from PIL import Image, ImageOps
 
+
+Image.init()
+
 def analyze_gif(blob):
     im = Image.open(blob)
     results = {


### PR DESCRIPTION
This makes the comparison a bit more fair.

1. Pillow loads image codecs lazily. This heavily affects max time of `header` tests and slightly affects avg time. `Image.init()` call at start of the script fixes this.

Before:
  
 ```
JPEG 1920x1080 header read:	1920x1080,	avg: 0.053078 ms	min: 0.038862 ms	max: 95.713854 ms
PNG 1920x1080 header read:	1920x1080,	avg: 0.050190 ms	min: 0.043869 ms	max: 0.578165 ms
WEBP 1920x1080 header read:	1920x1080,	avg: 3.311477 ms	min: 0.232935 ms	max: 248.356104 ms
GIF 1920x1080 header read:	1920x1080,	avg: 0.033193 ms	min: 0.028849 ms	max: 5.729914 ms
```

After:

```
JPEG 1920x1080 header read:	1920x1080,	avg: 0.078423 ms	min: 0.073910 ms	max: 0.518084 ms
PNG 1920x1080 header read:	1920x1080,	avg: 0.053475 ms	min: 0.049829 ms	max: 0.409842 ms
WEBP 1920x1080 header read:	1920x1080,	avg: 0.961201 ms	min: 0.244856 ms	max: 8.344889 ms
GIF 1920x1080 header read:	1920x1080,	avg: 0.044504 ms	min: 0.036955 ms	max: 9.562016 ms
```

2. Lilliput uses `INTER_AREA` interpolation for OpenCV's resize function. Pillow uses a very flexible and high-quality resize based on convolutions. It allows to choose exact quality pf resizing and also affects performance. `LANCZOS` produces very harp images which looks much better than `INTER_AREA` interpolation. This affects not only the resize speed itself, but also speed of compression and the result size of coded images. `BICUBIC` filter a bit cheaper and its result is much closer to `INTER_AREA`, while still slightly better and shaper.

Before:

```
JPEG 1920x1080 => 800x600:	112307 Bytes,	avg: 32.13 ms	min: 30.00 ms	max: 41.77 ms
PNG 1920x1080 => 800x600:	846202 Bytes,	avg: 267.92 ms	min: 263.95 ms	max: 328.71 ms
WEBP 1920x1080 => 800x600:	92466 Bytes,	avg: 134.70 ms	min: 131.66 ms	max: 180.58 ms
GIF 1920x1080 => 800x600:	411470 Bytes,	avg: 102.21 ms	min: 98.08 ms	max: 129.57 ms
```

After:

```
JPEG 1920x1080 => 800x600:	107480 Bytes,	avg: 29.71 ms	min: 28.45 ms	max: 37.43 ms
PNG 1920x1080 => 800x600:	810489 Bytes,	avg: 278.79 ms	min: 270.78 ms	max: 336.85 ms
WEBP 1920x1080 => 800x600:	84690 Bytes,	avg: 132.98 ms	min: 128.04 ms	max: 304.28 ms
GIF 1920x1080 => 800x600:	411470 Bytes,	avg: 100.53 ms	min: 96.06 ms	max: 145.06 ms
```

3. There is an absolutely unnecessary conversion of color mode for Pillow. It adds some overheads and also converts PNG and WEBP images to RGBA mode. As a result, the size is bigger and compression is slower.